### PR TITLE
fix: provide dummy config for OpenAPI spec generation in CI

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -32,6 +32,8 @@ jobs:
 
       - name: Generate OpenAPI spec from backend build
         run: dotnet build backend/WaifuApi.Web/WaifuApi.Web.csproj -c Release
+        env:
+          ASPNETCORE_ENVIRONMENT: CI
 
       - uses: actions/setup-node@v4
         with:

--- a/backend/WaifuApi.Web/appsettings.CI.json
+++ b/backend/WaifuApi.Web/appsettings.CI.json
@@ -29,8 +29,8 @@
     "RequireTagReview": "false"
   },
   "Image": {
-    "DefaultPageSize": "30",
-    "MaxPageSize": "30",
+    "DefaultPageSize": "1",
+    "MaxPageSize": "-1",
     "MinWidth": "0",
     "MinHeight": "0",
     "MaxWidth": "10000",
@@ -38,23 +38,23 @@
   },
   "Tag": {
     "DefaultPageSize": "30",
-    "MaxPageSize": "30"
+    "MaxPageSize": "-1"
   },
   "Artist": {
     "DefaultPageSize": "30",
-    "MaxPageSize": "30"
+    "MaxPageSize": "-1"
   },
   "Album": {
     "DefaultPageSize": "30",
-    "MaxPageSize": "30"
+    "MaxPageSize": "-1"
   },
   "User": {
     "DefaultPageSize": "30",
-    "MaxPageSize": "30"
+    "MaxPageSize": "-1"
   },
   "Review": {
     "DefaultPageSize": "30",
-    "MaxPageSize": "30"
+    "MaxPageSize": "-1"
   },
   "ConnectionStrings": {
     "DefaultConnection": "Host=localhost;Database=dummy;Username=dummy;Password=dummy"

--- a/backend/WaifuApi.Web/appsettings.CI.json
+++ b/backend/WaifuApi.Web/appsettings.CI.json
@@ -1,0 +1,62 @@
+{
+  "API_BASE_PATH": "/",
+  "Frontend": {
+    "BaseUrl": "http://localhost"
+  },
+  "Cdn": {
+    "BaseUrl": "http://localhost"
+  },
+  "S3": {
+    "AccessKey": "dummy",
+    "SecretKey": "dummy",
+    "ServiceUrl": "http://localhost",
+    "BucketName": "dummy",
+    "Region": "us-east-1"
+  },
+  "Discord": {
+    "ClientId": "000000000000000000",
+    "ClientSecret": "dummy",
+    "RedirectUri": "http://localhost/callback"
+  },
+  "Jwt": {
+    "Key": "ci-dummy-key-that-is-long-enough-for-hmac-sha256-validation",
+    "Issuer": "ci",
+    "Audience": "ci"
+  },
+  "Moderation": {
+    "RequireImageReview": "false",
+    "RequireArtistReview": "false",
+    "RequireTagReview": "false"
+  },
+  "Image": {
+    "DefaultPageSize": "30",
+    "MaxPageSize": "30",
+    "MinWidth": "0",
+    "MinHeight": "0",
+    "MaxWidth": "10000",
+    "MaxHeight": "10000"
+  },
+  "Tag": {
+    "DefaultPageSize": "30",
+    "MaxPageSize": "30"
+  },
+  "Artist": {
+    "DefaultPageSize": "30",
+    "MaxPageSize": "30"
+  },
+  "Album": {
+    "DefaultPageSize": "30",
+    "MaxPageSize": "30"
+  },
+  "User": {
+    "DefaultPageSize": "30",
+    "MaxPageSize": "30"
+  },
+  "Review": {
+    "DefaultPageSize": "30",
+    "MaxPageSize": "30"
+  },
+  "ConnectionStrings": {
+    "DefaultConnection": "Host=localhost;Database=dummy;Username=dummy;Password=dummy"
+  }
+}


### PR DESCRIPTION
The deploy-docs workflow fails because the OpenAPI generation tool
bootstraps the app, triggering config validation that requires secrets
not available in CI. Add appsettings.CI.json with placeholder values
and set ASPNETCORE_ENVIRONMENT=CI in the workflow build step.

https://claude.ai/code/session_01UQ3qdVtb8J9Pe2UfcuzD54