### PR TITLE
fix: correct OpenAPI spec filename in Docusaurus config

### DIFF
--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -54,8 +54,8 @@ const config: Config = {
         config: {
           waifuApi: {
             // Generated at build time by Microsoft.Extensions.ApiDescription.Server
-            // The spec is output to ../openapi/v1.json by `dotnet build`
-            specPath: "../openapi/v1.json",
+            // The spec is output to ../openapi/{ProjectName}.json by `dotnet build`
+            specPath: "../openapi/WaifuApi.Web.json",
             outputDir: "docs/api",
             sidebarOptions: {
               groupPathsBy: "tag",


### PR DESCRIPTION
The Microsoft.Extensions.ApiDescription.Server package outputs the spec
as {ProjectName}.json (WaifuApi.Web.json), not {DocumentName}.json (v1.json).

https://claude.ai/code/session_01WZMk6ftj4uYcy1nPK4jAhg