### PR TITLE
feat: add album stats - top album users, album image count in user DTO, update icons

### DIFF
--- a/backend/WaifuApi.Application/Common/Models/UserDto.cs
+++ b/backend/WaifuApi.Application/Common/Models/UserDto.cs
@@ -16,6 +16,7 @@ public class UserDto
     public long ApiKeyRequestCount { get; set; }
     public long JwtRequestCount { get; set; }
     public long UploadedImageCount { get; set; }
+    public long AlbumImageCount { get; set; }
 }
 
 public class UserMinimalDto

--- a/backend/WaifuApi.Application/Features/Stats/GetAdminStats/Query.cs
+++ b/backend/WaifuApi.Application/Features/Stats/GetAdminStats/Query.cs
@@ -88,6 +88,18 @@ public class GetAdminStatsQueryHandler : IRequestHandler<GetAdminStatsQuery, Adm
             .Take(10)
             .ToListAsync(cancellationToken);
 
+        var topAlbumUsers = await _context.Users
+            .Select(u => new AlbumUserStatDto
+            {
+                Id = u.Id,
+                Name = u.Name,
+                AlbumImageCount = _context.AlbumItems.Count(ai => _context.Albums.Any(a => a.Id == ai.AlbumId && a.UserId == u.Id))
+            })
+            .Where(u => u.AlbumImageCount > 0)
+            .OrderByDescending(u => u.AlbumImageCount)
+            .Take(10)
+            .ToListAsync(cancellationToken);
+
         // Calculate authenticated vs unauthenticated
         var totalAuthenticatedRequests = await _context.Users.SumAsync(u => u.RequestCount, cancellationToken);
         var totalApiKeyRequests = await _context.Users.SumAsync(u => u.ApiKeyRequestCount, cancellationToken);
@@ -104,6 +116,7 @@ public class GetAdminStatsQueryHandler : IRequestHandler<GetAdminStatsQuery, Adm
             TopApiKeyUsers = topApiKeyUsers,
             TopJwtUsers = topJwtUsers,
             TopUploaders = topUploaders,
+            TopAlbumUsers = topAlbumUsers,
             TotalRequests = publicStats.TotalRequests,
             TotalAuthenticatedRequests = totalAuthenticatedRequests,
             TotalUnauthenticatedRequests = totalUnauthenticatedRequests,
@@ -124,6 +137,7 @@ public class AdminStatsDto
     public List<UserStatDto> TopApiKeyUsers { get; set; } = new();
     public List<UserStatDto> TopJwtUsers { get; set; } = new();
     public List<UploaderStatDto> TopUploaders { get; set; } = new();
+    public List<AlbumUserStatDto> TopAlbumUsers { get; set; } = new();
     
     // Public stats included
     public long TotalRequests { get; set; }
@@ -156,4 +170,11 @@ public class UploaderStatDto
     public long Id { get; set; }
     public string Name { get; set; } = string.Empty;
     public long UploadedImageCount { get; set; }
+}
+
+public class AlbumUserStatDto
+{
+    public long Id { get; set; }
+    public string Name { get; set; } = string.Empty;
+    public long AlbumImageCount { get; set; }
 }

--- a/backend/WaifuApi.Application/Features/Users/GetUsers/Query.cs
+++ b/backend/WaifuApi.Application/Features/Users/GetUsers/Query.cs
@@ -54,7 +54,8 @@ public class GetUsersQueryHandler : IQueryHandler<GetUsersQuery, PaginatedList<U
                 RequestCount = u.RequestCount,
                 ApiKeyRequestCount = u.ApiKeyRequestCount,
                 JwtRequestCount = u.JwtRequestCount,
-                UploadedImageCount = _context.Images.Count(i => i.UploaderId == u.Id && i.ReviewStatus == ReviewStatus.Accepted)
+                UploadedImageCount = _context.Images.Count(i => i.UploaderId == u.Id && i.ReviewStatus == ReviewStatus.Accepted),
+                AlbumImageCount = _context.AlbumItems.Count(ai => _context.Albums.Any(a => a.Id == ai.AlbumId && a.UserId == u.Id))
             }).ToListAsync(cancellationToken);
 
             return new PaginatedList<UserDto>(result, result.Count, 1, result.Count);
@@ -81,7 +82,8 @@ public class GetUsersQueryHandler : IQueryHandler<GetUsersQuery, PaginatedList<U
             RequestCount = u.RequestCount,
             ApiKeyRequestCount = u.ApiKeyRequestCount,
             JwtRequestCount = u.JwtRequestCount,
-            UploadedImageCount = _context.Images.Count(i => i.UploaderId == u.Id && i.ReviewStatus == ReviewStatus.Accepted)
+            UploadedImageCount = _context.Images.Count(i => i.UploaderId == u.Id && i.ReviewStatus == ReviewStatus.Accepted),
+            AlbumImageCount = _context.AlbumItems.Count(ai => _context.Albums.Any(a => a.Id == ai.AlbumId && a.UserId == u.Id))
         }).OrderByDescending(u => u.UploadedImageCount);
 
         var count = await query.CountAsync(cancellationToken);

--- a/frontend/src/pages/AdminStats.tsx
+++ b/frontend/src/pages/AdminStats.tsx
@@ -1,6 +1,6 @@
 ﻿import { useState, useEffect } from 'react';
 import api from '../services/api';
-import { BarChart, Activity, Calendar, Image as ImageIcon, Tag as TagIcon, Users, Trophy, ShieldCheck, UserX, Key, Globe, Scale, Upload } from 'lucide-react';
+import { BarChart, Activity, Calendar, Image as ImageIcon, Images, Tag as TagIcon, Users, Trophy, ShieldCheck, UserX, Key, Globe, Scale, Upload } from 'lucide-react';
 import { useRequireAuth } from '../hooks/useRequireAuth';
 import { Role } from '../types';
 import { Link } from 'react-router-dom';
@@ -24,6 +24,12 @@ interface UploaderStat {
     uploadedImageCount: number;
 }
 
+interface AlbumUserStat {
+    id: number;
+    name: string;
+    albumImageCount: number;
+}
+
 interface AdminStats {
     requestsToday: number;
     history: DailyStat[];
@@ -31,6 +37,7 @@ interface AdminStats {
     topApiKeyUsers: UserStat[];
     topJwtUsers: UserStat[];
     topUploaders: UploaderStat[];
+    topAlbumUsers: AlbumUserStat[];
     totalRequests: number;
     totalAuthenticatedRequests: number;
     totalUnauthenticatedRequests: number;
@@ -367,6 +374,29 @@ const AdminStats = () => {
                             </div>
                         ))}
                         {(!stats?.topUploaders || stats.topUploaders.length === 0) && (
+                            <div className="text-center text-muted-foreground py-4">No data yet.</div>
+                        )}
+                    </div>
+                </div>
+
+                {/* TOP ALBUM USERS */}
+                <div className="bg-card border border-border rounded-xl overflow-hidden shadow-sm p-6">
+                    <h2 className="text-xl font-bold flex items-center gap-2 mb-6">
+                        <Images size={20} className="text-pink-500" /> Top Album Users
+                    </h2>
+                    <div className="space-y-4">
+                        {stats?.topAlbumUsers.map((u, i) => (
+                            <div key={u.id} className="flex items-center justify-between p-3 bg-secondary/30 rounded-lg">
+                                <div className="flex items-center gap-3 min-w-0">
+                                    <div className={`w-6 h-6 rounded-full flex items-center justify-center font-bold text-xs shrink-0 ${i === 0 ? 'bg-pink-500/20 text-pink-600' : i === 1 ? 'bg-gray-400/20 text-gray-500' : i === 2 ? 'bg-orange-500/20 text-orange-600' : 'bg-secondary text-muted-foreground'}`}>
+                                        {i + 1}
+                                    </div>
+                                    <Link to={`/users?includedIds=${u.id}`} className="font-medium truncate hover:text-primary hover:underline" title={u.name}>{u.name}</Link>
+                                </div>
+                                <span className="font-mono text-sm font-bold shrink-0">{u.albumImageCount.toLocaleString()}</span>
+                            </div>
+                        ))}
+                        {(!stats?.topAlbumUsers || stats.topAlbumUsers.length === 0) && (
                             <div className="text-center text-muted-foreground py-4">No data yet.</div>
                         )}
                     </div>

--- a/frontend/src/pages/Users.tsx
+++ b/frontend/src/pages/Users.tsx
@@ -2,7 +2,7 @@
 import api from '../services/api';
 import { User, Role } from '../types';
 import { useNotification } from '../context/NotificationContext';
-import { Users as UsersIcon, Shield, Ban, CheckCircle, Image } from 'lucide-react';
+import { Users as UsersIcon, Shield, Ban, CheckCircle, Upload, Images } from 'lucide-react';
 import { Link } from 'react-router-dom';
 import ConfirmModal from '../components/modals/ConfirmModal';
 import SearchableSelect from '../components/SearchableSelect';
@@ -93,6 +93,7 @@ const Users = () => {
                             <th className="p-4 font-bold text-sm text-muted-foreground">User</th>
                             <th className="p-4 font-bold text-sm text-muted-foreground">Discord ID</th>
                             <th className="p-4 font-bold text-sm text-muted-foreground">Uploads</th>
+                            <th className="p-4 font-bold text-sm text-muted-foreground">Albums</th>
                             <th className="p-4 font-bold text-sm text-muted-foreground">Total Req</th>
                             <th className="p-4 font-bold text-sm text-muted-foreground">API Key</th>
                             <th className="p-4 font-bold text-sm text-muted-foreground">Web</th>
@@ -103,7 +104,7 @@ const Users = () => {
                         </thead>
                         <tbody>
                         {loading ? (
-                            [...Array(5)].map((_, i) => <tr key={i}><td colSpan={10} className="p-4"><div className="h-10 bg-muted rounded animate-pulse"/></td></tr>)
+                            [...Array(5)].map((_, i) => <tr key={i}><td colSpan={11} className="p-4"><div className="h-10 bg-muted rounded animate-pulse"/></td></tr>)
                         ) : users.map(user => (
                             <tr key={user.id} className="border-b border-border last:border-0 hover:bg-secondary/30 transition-colors">
                                 <td className="p-4 font-mono text-sm">{user.id}</td>
@@ -115,9 +116,15 @@ const Users = () => {
                                         className="inline-flex items-center gap-1.5 text-sm font-mono text-primary hover:underline"
                                         title="View uploaded images"
                                     >
-                                        <Image size={14} />
+                                        <Upload size={14} />
                                         {user.uploadedImageCount?.toLocaleString() || 0}
                                     </Link>
+                                </td>
+                                <td className="p-4">
+                                    <span className="inline-flex items-center gap-1.5 text-sm font-mono text-pink-500" title="Images in albums">
+                                        <Images size={14} />
+                                        {user.albumImageCount?.toLocaleString() || 0}
+                                    </span>
                                 </td>
                                 <td className="p-4 font-mono text-sm">{user.requestCount?.toLocaleString() || 0}</td>
                                 <td className="p-4 font-mono text-sm text-blue-500">{user.apiKeyRequestCount?.toLocaleString() || 0}</td>

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -51,6 +51,7 @@ export interface User {
   apiKeyRequestCount?: number;
   jwtRequestCount?: number;
   uploadedImageCount?: number;
+  albumImageCount?: number;
 }
 
 export interface AlbumDto {


### PR DESCRIPTION
- Add AlbumImageCount to UserDto and compute it from AlbumItems joined to user's Albums
- Add TopAlbumUsers stat (top 10 users by album image count) to admin stats endpoint
- Add AlbumUserStatDto for the new stat
- Add "Top Album Users" card (pink theme) to admin dashboard
- Add "Albums" column in users table showing album image count with Images icon
- Change uploads column icon from Image to Upload for clarity

https://claude.ai/code/session_01CUPqD8AMFRCHDubUTyCF5t