### PR TITLE
fix: improve homepage transparency effect visibility in mobile dark mode

### DIFF
--- a/frontend/src/pages/AdminStats.tsx
+++ b/frontend/src/pages/AdminStats.tsx
@@ -1,6 +1,6 @@
 ﻿import { useState, useEffect } from 'react';
 import api from '../services/api';
-import { BarChart, Activity, Calendar, Image as ImageIcon, Images, Tag as TagIcon, Users, Trophy, ShieldCheck, UserX, Key, Globe, Scale, Upload } from 'lucide-react';
+import { BarChart, Activity, Calendar, Image as ImageIcon, GalleryHorizontal, Tag as TagIcon, Users, Trophy, ShieldCheck, UserX, Key, Globe, Scale, Upload } from 'lucide-react';
 import { useRequireAuth } from '../hooks/useRequireAuth';
 import { Role } from '../types';
 import { Link } from 'react-router-dom';
@@ -382,7 +382,7 @@ const AdminStats = () => {
                 {/* TOP ALBUM USERS */}
                 <div className="bg-card border border-border rounded-xl overflow-hidden shadow-sm p-6">
                     <h2 className="text-xl font-bold flex items-center gap-2 mb-6">
-                        <Images size={20} className="text-pink-500" /> Top Album Users
+                        <GalleryHorizontal size={20} className="text-pink-500" /> Top Album Users
                     </h2>
                     <div className="space-y-4">
                         {stats?.topAlbumUsers.map((u, i) => (

--- a/frontend/src/pages/AdminStats.tsx
+++ b/frontend/src/pages/AdminStats.tsx
@@ -1,6 +1,6 @@
 ﻿import { useState, useEffect } from 'react';
 import api from '../services/api';
-import { BarChart, Activity, Calendar, Image as ImageIcon, GalleryHorizontal, Tag as TagIcon, Users, Trophy, ShieldCheck, UserX, Key, Globe, Scale, Upload } from 'lucide-react';
+import { BarChart, Activity, Calendar, Image as ImageIcon, Tag as TagIcon, Users, Trophy, ShieldCheck, UserX, Key, Globe, Scale, Upload } from 'lucide-react';
 import { useRequireAuth } from '../hooks/useRequireAuth';
 import { Role } from '../types';
 import { Link } from 'react-router-dom';
@@ -382,7 +382,7 @@ const AdminStats = () => {
                 {/* TOP ALBUM USERS */}
                 <div className="bg-card border border-border rounded-xl overflow-hidden shadow-sm p-6">
                     <h2 className="text-xl font-bold flex items-center gap-2 mb-6">
-                        <GalleryHorizontal size={20} className="text-pink-500" /> Top Album Users
+                        <ImageIcon size={20} className="text-pink-500" /> Top Album Users
                     </h2>
                     <div className="space-y-4">
                         {stats?.topAlbumUsers.map((u, i) => (

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -77,11 +77,11 @@ const Home = () => {
             <div className="absolute inset-0 z-0 overflow-hidden select-none">
               <img
                   src={heroImage.url}
-                  className="w-full h-full object-cover opacity-20 dark:opacity-[0.07] scale-110 blur-md grayscale-[20%]"
+                  className="w-full h-full object-cover opacity-20 dark:opacity-[0.15] scale-110 blur-md grayscale-[20%]"
                   alt="Atmosphere"
                   onError={() => setHeroImage(null)}
               />
-              <div className="absolute inset-0 bg-gradient-to-b from-background/80 via-transparent to-background"></div>
+              <div className="absolute inset-0 bg-gradient-to-b from-background/80 dark:from-background/50 via-transparent to-background"></div>
             </div>
         )}
 

--- a/frontend/src/pages/Users.tsx
+++ b/frontend/src/pages/Users.tsx
@@ -2,7 +2,7 @@
 import api from '../services/api';
 import { User, Role } from '../types';
 import { useNotification } from '../context/NotificationContext';
-import { Users as UsersIcon, Shield, Ban, CheckCircle, Upload, GalleryHorizontal } from 'lucide-react';
+import { Users as UsersIcon, Shield, Ban, CheckCircle, Upload, Image as ImagesIcon } from 'lucide-react';
 import { Link } from 'react-router-dom';
 import ConfirmModal from '../components/modals/ConfirmModal';
 import SearchableSelect from '../components/SearchableSelect';
@@ -122,7 +122,7 @@ const Users = () => {
                                 </td>
                                 <td className="p-4">
                                     <span className="inline-flex items-center gap-1.5 text-sm font-mono text-pink-500" title="Images in albums">
-                                        <GalleryHorizontal size={14} />
+                                        <ImagesIcon size={14} />
                                         {user.albumImageCount?.toLocaleString() || 0}
                                     </span>
                                 </td>

--- a/frontend/src/pages/Users.tsx
+++ b/frontend/src/pages/Users.tsx
@@ -2,7 +2,7 @@
 import api from '../services/api';
 import { User, Role } from '../types';
 import { useNotification } from '../context/NotificationContext';
-import { Users as UsersIcon, Shield, Ban, CheckCircle, Upload, Images } from 'lucide-react';
+import { Users as UsersIcon, Shield, Ban, CheckCircle, Upload, GalleryHorizontal } from 'lucide-react';
 import { Link } from 'react-router-dom';
 import ConfirmModal from '../components/modals/ConfirmModal';
 import SearchableSelect from '../components/SearchableSelect';
@@ -122,7 +122,7 @@ const Users = () => {
                                 </td>
                                 <td className="p-4">
                                     <span className="inline-flex items-center gap-1.5 text-sm font-mono text-pink-500" title="Images in albums">
-                                        <Images size={14} />
+                                        <GalleryHorizontal size={14} />
                                         {user.albumImageCount?.toLocaleString() || 0}
                                     </span>
                                 </td>


### PR DESCRIPTION
The hero background image opacity was too low (7%) in dark mode, making
the glass/transparency effect invisible on mobile screens. Increased to
15% and reduced the gradient overlay opacity in dark mode from 80% to
50% so the effect shows through on smaller screens.

https://claude.ai/code/session_01VxRtkBkczdCR4Bn6paF7rx