### PR TITLE
Fix docs version mismatch by using MinVer CLI instead of MSBuild task

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -35,8 +35,19 @@ jobs:
         with:
           dotnet-version: "10.0.x"
 
+      - name: Install MinVer CLI
+        run: dotnet tool install --global minver-cli
+
+      - name: Calculate version
+        id: version
+        working-directory: ./backend
+        run: |
+          VERSION=$(minver --tag-prefix v)
+          echo "VERSION=$VERSION" >> $GITHUB_OUTPUT
+          echo "Calculated version: $VERSION"
+
       - name: Generate OpenAPI spec from backend build
-        run: dotnet build backend/WaifuApi.Web/WaifuApi.Web.csproj -c Release /p:OpenApiGenerateDocumentsOnBuild=true
+        run: dotnet build backend/WaifuApi.Web/WaifuApi.Web.csproj -c Release /p:OpenApiGenerateDocumentsOnBuild=true /p:MinVerVersionOverride=${{ steps.version.outputs.VERSION }}
         env:
           ASPNETCORE_ENVIRONMENT: CI
 


### PR DESCRIPTION
The MinVer MSBuild task (LibGit2Sharp) resolves tags incorrectly in
GitHub Actions checkout environment, producing pre-release versions
like 7.1.3-alpha.0.1 even when on a tagged commit. Use the MinVer CLI
with MinVerVersionOverride, matching the approach in docker-image.yml.

https://claude.ai/code/session_01GZCrnnuyBqeGFhTAkH92Tw