### PR TITLE
Enforce review status filtering permissions across API endpoints

### DIFF
--- a/backend/WaifuApi.Web/Controllers/AlbumsController.cs
+++ b/backend/WaifuApi.Web/Controllers/AlbumsController.cs
@@ -1,6 +1,7 @@
 using System.ComponentModel.DataAnnotations;
 using System.Security.Claims;
 using Mediator;
+using WaifuApi.Application.Common.Exceptions;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
@@ -204,6 +205,7 @@ public class AlbumsController : ControllerBase
     [ProducesResponseType(typeof(PaginatedList<ImageDto>), StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(ValidationErrorResponse), StatusCodes.Status400BadRequest)]
     [ProducesResponseType(typeof(ErrorResponse), StatusCodes.Status404NotFound)]
+    [ProducesResponseType(typeof(ErrorResponse), StatusCodes.Status403Forbidden)]
     public async Task<ActionResult<PaginatedList<ImageDto>>> GetAlbumImages([FromRoute] string userId, [FromRoute] string albumId, [FromQuery] GetImagesRequest request)
     {
         var resolvedUserId = await _currentUserService.ResolveUserIdAsync(userId);
@@ -212,6 +214,13 @@ public class AlbumsController : ControllerBase
         var resolvedAlbumId = await _currentUserService.ResolveAlbumIdAsync(resolvedUserId, albumId);
 
         if (resolvedAlbumId == null) return NotFound();
+
+        // Check permission for non-Accepted review status filtering
+        if (!_currentUserService.IsModeratorOrAdmin &&
+            (request.ReviewStatus != ReviewStatusFilter.Accepted || request.ChildReviewStatus != ReviewStatusFilter.Accepted))
+        {
+            throw new ForbiddenException("Filtering by non-accepted review status is only available to moderators and admins.");
+        }
 
         // Map Request to Query with AlbumId
         var query = new GetImagesQuery
@@ -233,7 +242,9 @@ public class AlbumsController : ControllerBase
             PageSize = request.PageSize,
             AlbumId = resolvedAlbumId,
             UserId = _currentUserService.UserId,
-            ReviewStatus = ReviewStatusFilter.All
+            IsModeratorOrAdmin = _currentUserService.IsModeratorOrAdmin,
+            ReviewStatus = request.ReviewStatus,
+            ChildReviewStatus = request.ChildReviewStatus
         };
 
         var images = await _mediator.Send(query);

--- a/backend/WaifuApi.Web/Controllers/ArtistsController.cs
+++ b/backend/WaifuApi.Web/Controllers/ArtistsController.cs
@@ -7,6 +7,7 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using WaifuApi.Application.Common.Constants;
+using WaifuApi.Application.Common.Exceptions;
 using WaifuApi.Application.Common.Models;
 using WaifuApi.Application.Features.Artists.CreateArtist;
 using WaifuApi.Application.Features.Artists.DeleteArtist;
@@ -60,8 +61,15 @@ public class ArtistsController : ControllerBase
     /// <response code="200">Returns the list of artists.</response>
     [HttpGet]
     [ProducesResponseType(typeof(PaginatedList<ArtistDto>), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ErrorResponse), StatusCodes.Status403Forbidden)]
     public async Task<ActionResult<PaginatedList<ArtistDto>>> Get([FromQuery] GetArtistsRequest request)
     {
+        // Check permission for non-Accepted review status filtering
+        if (!_currentUser.IsModeratorOrAdmin && request.ReviewStatus != ReviewStatusFilter.Accepted)
+        {
+            throw new ForbiddenException("Filtering by non-accepted review status is only available to moderators and admins.");
+        }
+
         var query = new GetArtistsQuery
         {
             Name = request.Name,
@@ -69,7 +77,7 @@ public class ArtistsController : ControllerBase
             Page = request.Page,
             PageSize = request.PageSize,
             IsModeratorOrAdmin = _currentUser.IsModeratorOrAdmin,
-            ReviewStatus = _currentUser.IsModeratorOrAdmin ? request.ReviewStatus : ReviewStatusFilter.Accepted
+            ReviewStatus = request.ReviewStatus
         };
 
         var artists = await _mediator.Send(query);

--- a/backend/WaifuApi.Web/Controllers/ImagesController.cs
+++ b/backend/WaifuApi.Web/Controllers/ImagesController.cs
@@ -9,6 +9,7 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using WaifuApi.Application.Common.Constants;
+using WaifuApi.Application.Common.Exceptions;
 using WaifuApi.Application.Common.Models;
 using WaifuApi.Application.Features.Images.GetImageById;
 using WaifuApi.Application.Features.Images.GetImages;
@@ -62,8 +63,16 @@ public class ImagesController : ControllerBase
     [HttpGet]
     [ProducesResponseType(typeof(PaginatedList<ImageDto>), StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(ValidationErrorResponse), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(typeof(ErrorResponse), StatusCodes.Status403Forbidden)]
     public async Task<ActionResult<PaginatedList<ImageDto>>> Get([FromQuery] GetImagesRequest request)
     {
+        // Check permission for non-Accepted review status filtering
+        if (!_currentUser.IsModeratorOrAdmin &&
+            (request.ReviewStatus != ReviewStatusFilter.Accepted || request.ChildReviewStatus != ReviewStatusFilter.Accepted))
+        {
+            throw new ForbiddenException("Filtering by non-accepted review status is only available to moderators and admins.");
+        }
+
         var query = new GetImagesQuery
         {
             IsNsfw = request.IsNsfw,
@@ -84,8 +93,8 @@ public class ImagesController : ControllerBase
             UserId = _currentUser.UserId,
             IsModeratorOrAdmin = _currentUser.IsModeratorOrAdmin,
             UploaderId = _currentUser.IsModeratorOrAdmin ? request.UploaderId : null,
-            ReviewStatus = _currentUser.IsModeratorOrAdmin ? request.ReviewStatus : ReviewStatusFilter.Accepted,
-            ChildReviewStatus = _currentUser.IsModeratorOrAdmin ? request.ChildReviewStatus : ReviewStatusFilter.Accepted
+            ReviewStatus = request.ReviewStatus,
+            ChildReviewStatus = request.ChildReviewStatus
         };
 
         var images = await _mediator.Send(query);
@@ -107,10 +116,16 @@ public class ImagesController : ControllerBase
     [HttpGet("{id:long}")]
     [ProducesResponseType(typeof(ImageDto), StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(ErrorResponse), StatusCodes.Status404NotFound)]
+    [ProducesResponseType(typeof(ErrorResponse), StatusCodes.Status403Forbidden)]
     public async Task<ActionResult<ImageDto>> GetById([FromRoute] long id, [FromQuery] ReviewStatusFilter childReviewStatus = ReviewStatusFilter.Accepted)
     {
-        var effectiveChildReviewStatus = _currentUser.IsModeratorOrAdmin ? childReviewStatus : ReviewStatusFilter.Accepted;
-        var image = await _mediator.Send(new GetImageByIdQuery(id, _currentUser.UserId ?? 0, _currentUser.IsModeratorOrAdmin, effectiveChildReviewStatus));
+        // Check permission for non-Accepted review status filtering
+        if (!_currentUser.IsModeratorOrAdmin && childReviewStatus != ReviewStatusFilter.Accepted)
+        {
+            throw new ForbiddenException("Filtering by non-accepted review status is only available to moderators and admins.");
+        }
+
+        var image = await _mediator.Send(new GetImageByIdQuery(id, _currentUser.UserId ?? 0, _currentUser.IsModeratorOrAdmin, childReviewStatus));
         return Ok(image);
     }
 

--- a/backend/WaifuApi.Web/Controllers/TagsController.cs
+++ b/backend/WaifuApi.Web/Controllers/TagsController.cs
@@ -7,6 +7,7 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using WaifuApi.Application.Common.Constants;
+using WaifuApi.Application.Common.Exceptions;
 using WaifuApi.Application.Common.Models;
 using WaifuApi.Application.Features.Tags.GetTags;
 using WaifuApi.Application.Features.Tags.CreateTag;
@@ -61,8 +62,15 @@ public class TagsController : ControllerBase
     [HttpGet]
     [ProducesResponseType(typeof(PaginatedList<TagDto>), StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(ValidationErrorResponse), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(typeof(ErrorResponse), StatusCodes.Status403Forbidden)]
     public async Task<ActionResult<PaginatedList<TagDto>>> Get([FromQuery] GetTagsRequest request)
     {
+        // Check permission for non-Accepted review status filtering
+        if (!_currentUser.IsModeratorOrAdmin && request.ReviewStatus != ReviewStatusFilter.Accepted)
+        {
+            throw new ForbiddenException("Filtering by non-accepted review status is only available to moderators and admins.");
+        }
+
         var query = new GetTagsQuery
         {
             Name = request.Name,
@@ -71,7 +79,7 @@ public class TagsController : ControllerBase
             Page = request.Page,
             PageSize = request.PageSize,
             IsModeratorOrAdmin = _currentUser.IsModeratorOrAdmin,
-            ReviewStatus = _currentUser.IsModeratorOrAdmin ? request.ReviewStatus : ReviewStatusFilter.Accepted
+            ReviewStatus = request.ReviewStatus
         };
 
         var tags = await _mediator.Send(query);


### PR DESCRIPTION
## Summary
This PR implements explicit permission checks for review status filtering across all API endpoints that support filtering by review status. Non-moderator/admin users are now prevented from filtering by non-accepted review statuses, with proper error responses.

## Key Changes
- **Added permission validation** in `AlbumsController.GetAlbumImages()`, `ArtistsController.Get()`, `ImagesController.Get()`, `ImagesController.GetById()`, and `TagsController.Get()` to check if non-moderator/admin users attempt to filter by non-accepted review statuses
- **Throw `ForbiddenException`** when unauthorized users try to filter by non-accepted statuses, with descriptive error messages
- **Updated OpenAPI documentation** by adding `[ProducesResponseType(StatusCodes.Status403Forbidden)]` attributes to affected endpoints
- **Simplified query mapping** by removing conditional logic that was filtering review status based on user role - the controller now passes the requested status directly to the query handler, with permission validation happening upfront
- **Added missing import** of `WaifuApi.Application.Common.Exceptions` namespace in affected controllers

## Implementation Details
- Permission checks follow a consistent pattern across all endpoints: verify user is moderator/admin before allowing non-accepted review status filters
- The validation happens at the controller level before queries are sent to the mediator, providing early rejection of unauthorized requests
- Both `ReviewStatus` and `ChildReviewStatus` filters are validated where applicable (Images and Albums endpoints)
- Error responses are properly documented in OpenAPI/Swagger metadata for API consumers

https://claude.ai/code/session_01CvFufZtYatVqM35RJHdjqQ